### PR TITLE
Fix acceleration property typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ I welcome **suggestions, discussions, and contributions** from the community. I 
 │── 📜 CONTRIBUTING.md  # How to contribute  
 │── 📜 CODE_OF_CONDUCT.md  # Community guidelines  
 │  
-├── 📂 Simulink-Files/  # MATLAB & Simulink simulation models  
+├── 📂 Simulink files/  # MATLAB & Simulink simulation models
 │   ├── instructions.mlx  # Live script to open & load scenario  
 │   ├── main_model.slx  # Simulink model file  
 │   ├── plotResults.m  # MATLAB script for visualization  

--- a/Simulink files/HelperTrajectoryGenerator.m
+++ b/Simulink files/HelperTrajectoryGenerator.m
@@ -74,9 +74,8 @@ classdef HelperTrajectoryGenerator < matlab.System ...
         %   by the Global plan and deviation block.
         DeviationValue
         
-        %CartiationAcceleration CartiationAcceleration stores the
-        %acceleration of the vehicle.
-        CartiationAcceleration
+        %CartesianAcceleration Cartesian acceleration of the vehicle.
+        CartesianAcceleration
     end
     
     properties(Constant)
@@ -177,7 +176,7 @@ classdef HelperTrajectoryGenerator < matlab.System ...
             obj.PreviousTime = 0;
             
             % Initializing the Cartesian acceleration variable
-            obj.CartiationAcceleration = 0;
+            obj.CartesianAcceleration = 0;
             
             % Initializing the TrajectoryIdx variable
             obj.TrajectoryIdx = 0;
@@ -468,7 +467,7 @@ classdef HelperTrajectoryGenerator < matlab.System ...
             %UpdateCurrCurvAcc This updates acceleration from the trajectory.
             Dist2Traj = vecnorm(obj.Trajectory(:,1:2) - repmat(EgoActorPoses.Position(1:2),numTrajPoints,1),2,2);
             [~,MinIdxTraj] = min(Dist2Traj,[],1);
-            obj.CartiationAcceleration = obj.Trajectory(MinIdxTraj,6);
+            obj.CartesianAcceleration = obj.Trajectory(MinIdxTraj,6);
         end
         
         %------------------------------------------------------------------
@@ -484,7 +483,7 @@ classdef HelperTrajectoryGenerator < matlab.System ...
             end
             % Update waypoints
             if getCurrentTime(obj)>0 % after first planning cycle trajectory does exist
-                Cart_Acc  = obj.CartiationAcceleration;
+                Cart_Acc  = obj.CartesianAcceleration;
                 
                 % Get the Cartesian states from RefPointOnPath               
                 CartStates = [RefPointOnPath.RefPoseRr(1:2) RefPointOnPath.RefPoseRr(3)/180*pi RefPointOnPath.RefCurvature RefPointOnPath.RefVelocity Cart_Acc];


### PR DESCRIPTION
## Summary
- correct acceleration property name in HelperTrajectoryGenerator
- update README path to match directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b5e9cb9c8328b729caece199e505